### PR TITLE
Otable error when ordering column of type 'Currency'

### DIFF
--- a/src/Format/Currency.php
+++ b/src/Format/Currency.php
@@ -18,7 +18,7 @@
 		 */
 		public static function decimal($number, $decimals = 2, $dec_point = ",", $thousands_sep = ".")
 		{
-			return number_format($number, $decimals, $dec_point, $thousands_sep);
+			return number_format(floatval($number), $decimals, $dec_point, $thousands_sep);
 		}
 
 		/**


### PR DESCRIPTION
There was an error when I tried to order a column of type 'Currency' that was solved using the floatval function applied to the first parameter.
