### PR TITLE
added quotes for the query filter

### DIFF
--- a/src/QueryBuilder/QueryFilter.php
+++ b/src/QueryBuilder/QueryFilter.php
@@ -13,6 +13,7 @@ class QueryFilter
 
     public function __construct($fieldName, $compare, $values, $queryColumn = null)
     {
+        $this->pdo = DB::getPdo();
         $this->fieldName = $fieldName;
         $this->compare = $compare;
         $this->values = $values;
@@ -114,6 +115,9 @@ class QueryFilter
         } elseif ($this->isDate($value)) {
             return DB::raw("'$value'");
         }
+
+        $value = $this->pdo->quote($value);
+        
         return DB::raw("LOWER('$value')");
     }
 


### PR DESCRIPTION
@sebasparola please check

I have added a quote/escape functionality for the QueryFilter that is used for any user input in the table. This way we can allow searches with **'** and most importantly we close a SQL Injection spot.