### PR TITLE
Select filter does not show all available options

### DIFF
--- a/src/QueryBuilder/QueryBuilder.php
+++ b/src/QueryBuilder/QueryBuilder.php
@@ -240,7 +240,6 @@ class QueryBuilder
                 $this->applyPrefilter($query);
             }
 
-            $query->take(100);
             $query->prepare();
             
             $result = $query->get();


### PR DESCRIPTION
@espspinix Arne was complaining that the filters for the oReport were not showing all the available options. I've noticed that was related with the limit 100 when querying the possible options.
Maybe you still want to keep this limit.