### PR TITLE
added limit for auto filter values

### DIFF
--- a/src/QueryBuilder/QueryBuilder.php
+++ b/src/QueryBuilder/QueryBuilder.php
@@ -241,6 +241,8 @@ class QueryBuilder
             }
 
             $query->prepare();
+
+            $query->take(100);
             
             $result = $query->get();
 


### PR DESCRIPTION
@sebasparola please check

added limit of 100 to auto filter values, because otherwise the tables can hang when enormous amounts of data have to be retrieved. this feature in general should be limited in use, when a lot of filter values exist. a better possibility would be to allow typeahead searching of values for those types of fields